### PR TITLE
Remove first line back ticks

### DIFF
--- a/Allfiles/Labs/Mod1_Lab02/program.cs
+++ b/Allfiles/Labs/Mod1_Lab02/program.cs
@@ -1,4 +1,3 @@
- ```
  using System;
  using System.Collections.Generic;
  using System.Linq;


### PR DESCRIPTION
The three back ticks on the first line are MD syntax, and in a cs file they are a bug.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-