### PR TITLE
"Allow inbound ports" changes

### DIFF
--- a/Instructions/Labs/Module_2/LAB_04_Create a VNet.md
+++ b/Instructions/Labs/Module_2/LAB_04_Create a VNet.md
@@ -62,7 +62,8 @@ Create two VMs in the virtual network:
     | Password | Pa55w.rd1234 |
     | Confirm Password | Reenter password. |
     | **INBOUND PORT RULES** |  |
-    | Public inbound ports | Select **None**. |
+    | Public inbound ports | Select **Allow selected ports**. |
+    | Select inbound ports | Select **HTTP** and **RDP**.
     | **SAVE MONEY** |  |
     | Already have a Windows license? | Leave the default **No**. |
 
@@ -77,8 +78,7 @@ Create two VMs in the virtual network:
     | Virtual network | Leave the default **myVirtualNetwork**. |
     | Subnet | Leave the default **myVirtualSubnet (10.1.0.0/24)**. |
     | Public IP | Leave the default **(new) myVm1-ip**. |
-    | Public inbound ports | Select **Allow selected ports**. |
-    | Select inbound ports | Select **HTTP** and **RDP**.
+   
 
 1.  Select **Next : Management**.
 


### PR DESCRIPTION
# Module: 02
## Lab/Demo: 04

Fixes # .

Changes proposed in this pull request:

- The lab steps instruct students to create a VM and set Public inbound ports to None on the Basics tab, then set Public inbound ports to HTTP and RDP on the Networking tab of the Create a virtual machine blade. But it seems that something has changed in the process, because the "Select inbound ports" drop-down list is non-responsive using this technique. The changes I propose are to allow HTTP and RDP from the Basics tab instead.
-
-