### PR TITLE
Escape to ticks to improve compatibility

### DIFF
--- a/Instructions/Labs/Module_2/LAB_03_Create a Kubernetes Cluster.md
+++ b/Instructions/Labs/Module_2/LAB_03_Create a Kubernetes Cluster.md
@@ -133,7 +133,7 @@ To see current status, uptime, and resource usage for the Azure Vote pods, compl
 1.  Select your resource group, such as *myResourceGroup*, then select your AKS cluster, such as *myAKSCluster*.
 1.  Under **Monitoring** on the left-hand side, choose **Insights**
 1.  Across the top, choose to **+ Add Filter**
-1.  Select *Namespace* as the property, then choose *\<All but kube-system\>*
+1.  Select *Namespace* as the property, then choose `<All but kube-system>`
 1.  Choose to view the **Containers**.
 
     The *azure-vote-back* and *azure-vote-front* containers are displayed


### PR DESCRIPTION
# Module: 02
## Lab/Demo: 03

Fixes # .

Changes proposed in this pull request: Changed from escaped angle brackets to ticks to improve compatibility with all markdown parsers.

-
-
-